### PR TITLE
#29 Display images on top of info pages

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -497,6 +497,20 @@ function _bgimage_filter_thumb_process($text, $filter, $format) {
   return $text;
 }
 
+/**
+ * Get a rendered thumbnail image.
+ *
+ * Example of a thumbnail image:
+ * <img src="http://./files/styles/bg_small/public/108/K10/108K10LKZS3ROQHQYQY0BQY05Q10PQ9K5QC04QWKLK102QO04QA0LKB04QUKRKD00KDKWQVK9QB0UQB0GQF04QC05QC0.jpg?itok=QTeqhGF8" alt="" />
+ *
+ * @param stdclass $node
+ *   The node object.
+ *
+ * @return string
+ *   The rendered thumbnail image.
+ *
+ * @throws Exception
+ */
 function bgimage_thumb($node) {
   // e.g., for $node->nid = 1877
   // $base = 665891889baf9ad4d0cb1626a5f56fb5
@@ -508,13 +522,33 @@ function bgimage_thumb($node) {
   $prefix = bgimage_get_prefix($obfuscate);
   // $uri = public://raw/MZA/LMZ/MZALMZWLLZELSRWLFL9LKRJZLZ6LYL9LRZJZHZ9L0R3Z3LDZGRTLERDLHZCLHZULXZ9LFLWLFL.jpg
   $uri = 'public://raw/' . $prefix . $obfuscate  .'.jpg';
-  $rendered_image = theme('image_style', array('path' => $uri, 'style_name' => 'bg_small'));
   // <img src="http://./files/styles/bg_small/public/108/K10/108K10LKZS3ROQHQYQY0BQY05Q10PQ9K5QC04QWKLK102QO04QA0LKB04QUKRKD00KDKWQVK9QB0UQB0GQF04QC05QC0.jpg?itok=QTeqhGF8" alt="" />
-  return $rendered_image;
+  return theme('image_style', array(
+    'path' => $uri,
+    'style_name' => 'bg_small',
+    'alt' => $node->title,
+    'title' => $node->title,
+  ));
 }
 
+/**
+ * Get a thumbnail linkable image of node.
+ *
+ * @param stdclass $node
+ *   The node object.
+ * @return string
+ *   A link with image as thumbnail else empty.
+ */
 function bgimage_thumb_link($node) {
-  return l(bgimage_thumb($node), 'node/' . $node->nid, array('html' => TRUE));
+  if (!$node) {
+    return '';
+  }
+  return l(bgimage_thumb($node), 'node/' . $node->nid, array(
+    'html' => TRUE,
+    'attributes' => array(
+      'title' => $node->title,
+    ),
+  ));
 }
 
 /**

--- a/sites/all/modules/custom/bgpage/bgpage.ds.field.inc
+++ b/sites/all/modules/custom/bgpage/bgpage.ds.field.inc
@@ -227,23 +227,13 @@ function bgpage_representative_images($field) {
       $representative_images__nids = explode(',', $field_representative_images_value);
       foreach ($representative_images__nids as $representative_images__nid) {
         $bgimage__node = node_load($representative_images__nid);
-        // Render a thumbnail of the image.
-        $rendered_image = theme('image_style', array(
-          'path' => $bgimage__node->field_bgimage_image[LANGUAGE_NONE][0]['uri'],
-          'style_name' => 'bg_small',
-          'alt' => $bgimage__node->title,
-          'title' => $bgimage__node->title,
-        ));
         // We do this to simulate this as apache solr fetching documents.
         // in order to merge them later.
         $document__representative_image = new stdClass();
-        $document__representative_image->ss_bgimage_thumbnail = l($rendered_image, 'node/' . $bgimage__node->nid, array(
-          'attributes' => array(
-            'title' => $bgimage__node->title,
-          ),
-          'html' => TRUE));
+        $document__representative_image->ss_bgimage_thumbnail =  bgimage_thumb_link($bgimage__node);
         $representative_images[] = $document__representative_image;
       }
+      $limit_images_to_display = $limit_images_to_display - count($representative_images);
       // Remove representative images if we have more than our current limit to display.
       if (count($representative_images) > $limit_images_to_display) {
         // We get negative value so in array_splice it removes
@@ -267,8 +257,9 @@ function bgpage_representative_images($field) {
       if (isset($document->ss_bgimage_thumbnail)) {
         $output .= '<li>' . $document->ss_bgimage_thumbnail . '</li>';    
       }
-      else {
-        $output .= '<li>(Thumbnail image not currently available)</li>';
+      elseif (isset($document->entity_id)) {
+        // The image thumbnail has not been indexed by Solr. Fall back to MySQL.
+        $output .= '<li>' . bgimage_thumb_link(node_load($document->entity_id)) . '</li>';
       }
     }
     $output .= '</ul></div></div>';
@@ -304,7 +295,7 @@ function _bgpage_search_representative_images_for($bgpage_nid, $limit = 8) {
 
   $query = apachesolr_drupal_query('representative_images_' . $bgpage_nid, array());
   $query->addFilterSubQuery($filter_parent);
-  $query->addParam('fl', 'ss_bgimage_thumbnail');
+  $query->addParam('fl', 'entity_id,ss_bgimage_thumbnail');
   $query->addParam('rows', $limit);
   $query->addParam('sort', 'is_bgimage_rating_avg desc');
   $query->addParam('sort', 'is_bgimage_rating_count desc');


### PR DESCRIPTION
### Description

Display images on top of info pages.

### Testing steps

1. Log in as administrator
2. Locate any bug guide page
3. See the top of row images (they are coming from apache solr) see for instance on my local environment:

![image](https://user-images.githubusercontent.com/1582129/96826868-e41fb600-13f9-11eb-8e5e-648296d9b93b.png)

4. Now if I edit the guide page and in field "representative image" I insert a bgimage node id like "117472"
![image](https://user-images.githubusercontent.com/1582129/96826938-13cebe00-13fa-11eb-870b-6027d964df21.png)
5. Click Save
6. Notice how a new image is pushed at the beginning and the rest moves to the right.
7. Now let's edit the guide page and add 8 more bg image nids (in total we should have 9).
![image](https://user-images.githubusercontent.com/1582129/96827095-6c9e5680-13fa-11eb-89b8-f59aaef6b44c.png)

8. Click Save
9. Notice that ONLY 8 images are display instead of 9 since 8 is the limit and notice that apache solr images are NOT shown anymore since the priority has the representative image.

![image](https://user-images.githubusercontent.com/1582129/96827163-8d66ac00-13fa-11eb-84a5-a12b9ef895e0.png)


Additional note:

Check that when getting representative image I am adding title, alt and image style besides the link wrapper with title attribute as well.
See evidence:
![image](https://user-images.githubusercontent.com/1582129/96827252-c69f1c00-13fa-11eb-8881-8dfb8a2a4e53.png)



