### PR TITLE
#31 Contributor editor role cannot edit bgimages

### DIFF
--- a/sites/all/modules/custom/bgusers/bgusers.features.user_permission.inc
+++ b/sites/all/modules/custom/bgusers/bgusers.features.user_permission.inc
@@ -815,14 +815,18 @@ function bgusers_user_default_permissions() {
   // Exported permission: 'edit any bglink content'.
   $permissions['edit any bglink content'] = array(
     'name' => 'edit any bglink content',
-    'roles' => array(),
+    'roles' => array(
+      'contributing editor' => 'contributing editor',
+    ),
     'module' => 'node',
   );
 
   // Exported permission: 'edit any book_reference content'.
   $permissions['edit any book_reference content'] = array(
     'name' => 'edit any book_reference content',
-    'roles' => array(),
+    'roles' => array(
+      'contributing editor' => 'contributing editor',
+    ),
     'module' => 'node',
   );
 


### PR DESCRIPTION
### Description

Allow contributor editor role to:
- Edit any bgimage
- Edit any bglink content
- Edit any book_reference content

### Reference tickets

https://github.com/bugguide/bugguide/issues/31



### Testing steps

1. Log in as admin
2. Enable bgusers module
3. Go to /admin/content search for a bgimage, bglink or book reference, edit that one then copy the url and paste in an anonymous browser.
4. In an anonymous browser you should see access denied.
5. Log in as contributor editor role
6. Paste the previous url and should be able to edit bgimage, bglink or book reference.


Additional note

![image](https://user-images.githubusercontent.com/1582129/97608961-078dc680-19e1-11eb-9d66-f789fe40c90d.png)

Notice permissions have been exported successfully. 