### PR TITLE
#73 support cite in comments

### DIFF
--- a/sites/all/modules/custom/bg/bg.module
+++ b/sites/all/modules/custom/bg/bg.module
@@ -489,10 +489,6 @@ function bg_node_view_alter(&$build) {
  *   Html renderable array.
  */
 function _bg_node_comments_process_cite_html(&$build) {
-  // Check if we need to process citations of type [cite:123].
-  if (($build['#view_mode'] != 'full') || !isset($build['bgpage_citations'])) {
-    return;
-  }
   if (!isset($build['comments']['comments'])) {
     return;
   }


### PR DESCRIPTION
### Description

Support cite tag in comments

### Reference ticket

https://github.com/bugguide/bugguide/issues/73

### Testing steps

- [ ] Go to a forum topic
- [ ] Add comments for instance:
This comment contains a cite [cite:57]. Add Solidago as a host plant for Dejongia lobidactylus guide page [cite:20] Currently no information about host plants there, and mine, identification confirmed in caterpillar [cite:70], pupa, and adult stages this summer, have all been on goldenrod.
- [ ] Click on Save
- [ ] The comment should be converted like this:
This comment contains a cite (1). Add Solidago as a host plant for Dejongia lobidactylus guide page (2) Currently no information about host plants there, and mine, identification confirmed in caterpillar (3), pupa, and adult stages this summer, have all been on goldenrod.

**Works cited**
1. Butterflies and Moths
2. Centipedes
3. suborders elevated to order; please delete

--
See screenshot that this is working as expected:
![image](https://user-images.githubusercontent.com/1582129/98314003-2113ad00-1fa3-11eb-97f9-44c8c5b3095d.png)
