### PR TITLE
#16 replace statistics page

### DIFF
--- a/sites/all/modules/custom/bgstat/bgstat.module
+++ b/sites/all/modules/custom/bgstat/bgstat.module
@@ -315,7 +315,13 @@ function _bgstat_get_html_statistics_page() {
 
   foreach ($LOCATION_CODES as $abbrev => $name) {
     $count = db_query("SELECT COUNT(*) FROM {bgimage} WHERE location_code = :location_code", array(':location_code' => $abbrev))->fetchField();
-    $html .= "<tr><td>$name</td><td align='right'>" . $count . "<td align='right'>" . number_format(($count/$totalImageCount) * 100, 1) . "</td></tr>";
+    if ($count) {
+      $percentage = number_format(($count/$totalImageCount) * 100, 1);
+    }
+    else {
+      $percentage = "0";
+    }
+    $html .= "<tr><td>$name</td><td align='right'>" . $count . "<td align='right'>" . $percentage . "</td></tr>";
   }
   $html .= "</table>";
 


### PR DESCRIPTION
### Description

Display statistics page in node 11181

![image](https://user-images.githubusercontent.com/1582129/98587213-d3938a80-2297-11eb-8731-5ab9844e76da.png)



### Testing steps

- [ ] Go to /node/11181
- [ ] You should see statistics page similar as https://bugguide.net/node/view/11181

