### PR TITLE
#25 classification title

### DIFF
--- a/sites/all/modules/custom/bg/bg.module
+++ b/sites/all/modules/custom/bg/bg.module
@@ -686,7 +686,9 @@ function bg_block_view($delta = '') {
 }
 
 /**
- * Get title classification.
+ * Build the title differently according to the taxon.
+ *
+ * Variations are shown in https://github.com/bugguide/bugguide/issues/25
  *
  * @param stdClass $node
  * The node object.
@@ -697,38 +699,41 @@ function bg_block_view($delta = '') {
  * @throws \EntityFieldQueryException
  */
 function _bg_get_title_classification($node) {
-  global $TAXON_IDS;
-  global $TAXON_NAMES;
+    global $TAXON_IDS;
+    global $TAXON_NAMES;
 
-  $taxon_key = $node->field_taxon[LANGUAGE_NONE][0]['value'];
-  $scientific_name = !empty($node->field_scientific_name[LANGUAGE_NONE][0]['value']) ? $node->field_scientific_name[LANGUAGE_NONE][0]['value'] : '';
-  $common_name = !empty($node->field_common_name[LANGUAGE_NONE][0]['value']) ? $node->field_common_name[LANGUAGE_NONE][0]['value'] : '';
-  $taxon_name = !empty($TAXON_NAMES[$taxon_key]) ? $TAXON_NAMES[$taxon_key] : '';
-  if ($taxon_name) {
-    // Regarding to taxon.
-    if ($taxon_key >= $TAXON_IDS['Genus']) {
-      $scientific_names_from_all_taxons = _bg_get_all_scientific_names_from_all_taxon_of_a_specific_node($node);
-      $full_scientific_name = !empty($scientific_names_from_all_taxons['Genus']) ? $scientific_names_from_all_taxons['Genus'] : '';
-      if (!empty($scientific_names_from_all_taxons['Species'])) {
-        $full_scientific_name .= ' ' . $scientific_names_from_all_taxons['Species'];
-      }
-      if (!empty($scientific_names_from_all_taxons['Subspecies'])) {
-        $full_scientific_name .= ' ' . $scientific_names_from_all_taxons['Subspecies'];
-      }
-      if (empty($common_name) || $full_scientific_name === $common_name) {
-        return "$taxon_name $full_scientific_name";
-      }
-      elseif (!empty($common_name) && $full_scientific_name !== $common_name) {
-        return "$taxon_name $full_scientific_name - $common_name";
-      }
+    $taxon_key = $node->field_taxon[LANGUAGE_NONE][0]['value'];
+    $scientific_name = !empty($node->field_scientific_name[LANGUAGE_NONE][0]['value']) ? $node->field_scientific_name[LANGUAGE_NONE][0]['value'] : '';
+    $common_name = !empty($node->field_common_name[LANGUAGE_NONE][0]['value']) ? $node->field_common_name[LANGUAGE_NONE][0]['value'] : '';
+    $taxon_name = !empty($TAXON_NAMES[$taxon_key]) ? $TAXON_NAMES[$taxon_key] : '';
+    if ($taxon_name) {
+        // Species and Subspecies are below Genus and need special attention.
+        // Namely, we need to prepend the Genus name and, for subspecies, the species name.
+        if ($taxon_key >= $TAXON_IDS['Genus']) {
+            $scientific_names_from_all_taxons = _bg_get_all_scientific_names_from_all_taxon_of_a_specific_node($node);
+            $full_scientific_name = !empty($scientific_names_from_all_taxons['Genus']) ? $scientific_names_from_all_taxons['Genus'] : '';
+            if (!empty($scientific_names_from_all_taxons['Species'])) {
+                $full_scientific_name .= ' ' . $scientific_names_from_all_taxons['Species'];
+            }
+            if (!empty($scientific_names_from_all_taxons['Subspecies'])) {
+                $full_scientific_name .= ' ' . $scientific_names_from_all_taxons['Subspecies'];
+            }
+            if (empty($common_name) || $full_scientific_name === $common_name) {
+                return "$taxon_name $full_scientific_name";
+            } elseif (!empty($common_name) && $full_scientific_name !== $common_name) {
+                return "$taxon_name $full_scientific_name - $common_name";
+            }
+        }
+        if (empty($common_name) || $scientific_name === $common_name) {
+            return $taxon_name . ' ' . $scientific_name;
+        } elseif (!empty($common_name) && $scientific_name !== $common_name) {
+            return "$taxon_name $scientific_name - $common_name";
+        }
+    } else {
+        // This is a No Taxon node.
+        // No Taxon nodes use only the common name, not the scientific name.
+        return "$common_name";
     }
-  }
-  if (empty($common_name) || $scientific_name === $common_name) {
-    return $taxon_name . ' ' . $scientific_name;
-  }
-  elseif (!empty($common_name) && $scientific_name !== $common_name) {
-    return "$taxon_name $scientific_name - $common_name";
-  }
 }
 
 /**
@@ -739,6 +744,7 @@ function _bg_get_title_classification($node) {
  * @return array
  *   An array of scientific names from taxon.
  * @todo: Add missing example.
+ * @todo: Optimization - consider replacing this with solr-based queries (see bgpage.module)
  * @throws \EntityFieldQueryException
  */
 function _bg_get_all_scientific_names_from_all_taxon_of_a_specific_node($node) {


### PR DESCRIPTION
### Description

Replace node title and title bar for:

*   bgpage
*   bgimage  
    And whenever you visit "Info", "taxonomy", "data", "Images", "Books", "Links" you'll have the correct node title and title bar based on the classification.

### Testing steps

| Pattern | Example | D7 Path | Explanation |
| --- | --- | --- | --- |
| \[taxon\] \[scientific name\] - \[common name\] | https://bugguide.net/node/view/171 | /node/171 | This is a family and scientific name and common name are different |
| \[taxon\] \[scientific name\] | https://bugguide.net/node/view/168867 | /node/168867 | This is a Tribe so the taxon value is shown and the scientific name and common name are the same |
| \[scientific name\] | https://bugguide.net/node/view/1117170 | /node/1117170 | This is a "No Taxon" taxon so display of taxon value is suppressed. Additionally, scientific name and common name (which is "Series Cucujiformia") are the same so only one is displayed |
| \[taxon\] \[scientific name\] | https://bugguide.net/node/view/235160 | /node/235160 | This is a genus and the common name is the same |
| \[taxon\] \[computed scientific name\] | https://bugguide.net/node/view/235161 | /node/235161 | This is a species so the construction of the scientific name includes the Genus name and the species name. The common name is the same |
| \[taxon\] \[computed scientific name\] | https://bugguide.net/node/view/322385 | /node/322385 | This is a subspecies to the construction of the scientific name includes the Genus name and the species name and the subspecies name. The common name is the same and thus not displayed. |
| \[taxon\] \[computed scientific name\] - \[common name\] | https://bugguide.net/node/view/2959 | /node/2959 | This is a species so the scientific name contains both the Genus name and the species name. Also, the common name is different so it is included after a hyphen. |