### PR TITLE
remove double permission, correct description

### DIFF
--- a/sites/all/modules/custom/bgstat/bgstat.module
+++ b/sites/all/modules/custom/bgstat/bgstat.module
@@ -48,12 +48,8 @@ function bgstat_menu() {
 function bgstat_permission() {
   return array(
     'access bgstats' => array(
-      'title' => t('View badges denoting privileged roles'),
-      'description' => t('Make visible which other users have enhanced privileges.'),
-    ),
-    'administer bg utilities' => array(
-      'title' => t('Administer bg utilities'),
-      'description' => t('Perform bg maintenance tasks'),
+      'title' => t('View system statistics'),
+      'description' => t('Advanced statistics for administrative insight.'),
     )
   );
 }


### PR DESCRIPTION
bgstat module has a permission that bg module also has. Removing from bgstat module.

bgstat module has the wrong description for access bgstat permission. Fixing.