### PR TITLE
#88 Optimize views query for recent_images

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -948,3 +948,28 @@ function bgimage_form_bgimage_node_form_alter(&$form, &$form_state) {
     $form['field_bgimage_base']['#access'] = FALSE;
   }
 }
+
+/**
+ * Implements hook_views_pre_render().
+ *
+ * @param $view
+ *   The view object.
+ */
+function bgimage_views_pre_render(&$view) {
+  // For recent images views with display block show just 4 recent images
+  // that doesn't contain parent value 6.
+  if (($view->name === 'recent_images') && ($view->current_display == 'block')) {
+    $nids_not_containing_parent_6 = 0;
+    foreach ($view->result as $key => $record) {
+      $node = node_load($record->nid);
+      // If DOESN'T contain PARENT value 6.
+      $parent_value = bg_get_first_parent_nid($node);
+      if ($parent_value === '6' && $nids_not_containing_parent_6 < 4) {
+        $nids_not_containing_parent_6++;
+      }
+      else {
+        unset($view->result[$key]);
+      }
+    }
+  }
+}

--- a/sites/all/modules/custom/bgimage/bgimage.views_default.inc
+++ b/sites/all/modules/custom/bgimage/bgimage.views_default.inc
@@ -882,12 +882,6 @@ function bgimage_views_default_views() {
   $handler->display->display_options['filters']['type']['value'] = array(
     'bgimage' => 'bgimage',
   );
-  /* Filter criterion: Content: Parent (field_parent) */
-  $handler->display->display_options['filters']['field_parent_value']['id'] = 'field_parent_value';
-  $handler->display->display_options['filters']['field_parent_value']['table'] = 'field_data_field_parent';
-  $handler->display->display_options['filters']['field_parent_value']['field'] = 'field_parent_value';
-  $handler->display->display_options['filters']['field_parent_value']['operator'] = '!=';
-  $handler->display->display_options['filters']['field_parent_value']['value'] = '6';
 
   /* Display: Block */
   $handler = $view->new_display('block', 'Block', 'block');
@@ -900,7 +894,7 @@ function bgimage_views_default_views() {
   $handler->display->display_options['use_more_text'] = 'More recent images';
   $handler->display->display_options['defaults']['pager'] = FALSE;
   $handler->display->display_options['pager']['type'] = 'some';
-  $handler->display->display_options['pager']['options']['items_per_page'] = '4';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '30';
   $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['defaults']['style_plugin'] = FALSE;
   $handler->display->display_options['style_plugin'] = 'list';


### PR DESCRIPTION
### Description

Optimize recent images views block

### Testing steps

- [ ] The homepage should load quickly 
- [ ] 4 images should display as long as they don't have parent value of 6 