### PR TITLE
#107 Fix regression issue that DS field values are empty.

### DIFF
--- a/sites/all/modules/custom/bg/bg.module
+++ b/sites/all/modules/custom/bg/bg.module
@@ -632,7 +632,7 @@ function _bg_get_citations_html($text, &$citation_nids) {
     }
     return str_replace($find, $replace, $text);
   }
-  return NULL;
+  return $text;
 }
 
 /**

--- a/sites/all/modules/custom/bgsubscriptions/bgsubscriptions.module
+++ b/sites/all/modules/custom/bgsubscriptions/bgsubscriptions.module
@@ -19,8 +19,6 @@ function bgsubscriptions_ds_fields_info($entity_type) {
       'function' => 'bgsubscriptions_subscriptions',
       'file' => drupal_get_path('module', 'bgsubscriptions') . '/bgsubscriptions.ds.field.inc',
     );
-
-    return array($entity_type => $fields);
   }
-  return;
+  return array($entity_type => $fields);
 }


### PR DESCRIPTION
### Description

The field values from custom DS (display suite) field values were empty. For instance the subscribe button introduced https://github.com/bugguide/bugguide/pull/109 was empty.

### Testing steps

- [ ] Log in as contributor editor role
- [ ] Visit any bgpage
- [ ] You should see that the subscribe button is displayed as expected