### PR TITLE
#203 Set the bglink Info tab to point to the link's parent.

### DIFF
--- a/sites/all/modules/custom/bgpage/bgpage.module
+++ b/sites/all/modules/custom/bgpage/bgpage.module
@@ -184,6 +184,7 @@ function bgpage_menu_local_tasks_alter(&$data, $route_name) {
 
       case 'bgimage':
       case 'book_reference':
+      case 'bglink':
         $parentpath = $route_name['page_arguments'][0]->field_parent[LANGUAGE_NONE][0]['value'];
         $parents = explode(',', $parentpath);
         if (count($parents) > 0) {


### PR DESCRIPTION
Currently the Info tab on a bglink node points to the bglink node; it should
instead point to the bgpage parent node of the bglink.