### PR TITLE
#199 #191 Run the xbbcode filter before the 'convert urls' filter.

### DIFF
--- a/sites/all/modules/custom/bg/bg.features.filter.inc
+++ b/sites/all/modules/custom/bg/bg.features.filter.inc
@@ -29,14 +29,14 @@ function bg_filter_default_formats() {
         'settings' => array(),
       ),
       'filter_url' => array(
-        'weight' => 0,
+        'weight' => 5,
         'status' => 1,
         'settings' => array(
           'filter_url_length' => 72,
         ),
       ),
       'xbbcode' => array(
-        'weight' => 5,
+        'weight' => 0,
         'status' => 1,
         'settings' => array(
           'autoclose' => 0,


### PR DESCRIPTION
Currently the 'convert urls' filter runs before the xbbcode filter, so an input bbcode url like `[url=http://www.texasento.net/Pic_Tech.html]Overview[/url]` first gets converted by 'convert urls' to `[url=<a href="http://www.texasento.net/Pic_Tech.html]Overview[/url]">http://www.texasento.net/Pic_Tech.html]Overview[/url]</a>` (or something along those lines) and then things continue going downhill when that gets passed to the xbbcode [url] regex.