### PR TITLE
#165 Link thumbnails in advanced search view.

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.views_default.inc
+++ b/sites/all/modules/custom/bgimage/bgimage.views_default.inc
@@ -349,7 +349,7 @@ function bgimage_views_default_views() {
   $handler->display->display_options['fields']['field_bgimage_image']['click_sort_column'] = 'fid';
   $handler->display->display_options['fields']['field_bgimage_image']['settings'] = array(
     'image_style' => 'bg_small',
-    'image_link' => '',
+    'image_link' => 'content',
   );
   /* Field: Content: Nid */
   $handler->display->display_options['fields']['nid']['id'] = 'nid';


### PR DESCRIPTION
The thumbnail images returned from advanced search now link to their respective bgimage nodes.

For the record, to change this I went to http://bugguide.test/admin/structure/views/view/advanced_search, then
* clicked on "Content: Image (Image)" under Fields,
* changed "Link image to" to "Content",
* clicked Apply, then clicked Save.

* In the menu under Save chose "Export view",
* diffed the exported view with the existing exported Advanced Search view in bgimage.views_default.inc,
* and updated the existing Advanced Search exported view (there were some minor changes in the diff that weren't included in this patch).