### PR TITLE
#210 Allow adding images to the root node even though it has no parent.

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -301,7 +301,7 @@ function bgimage_node_validate($node, $form, &$form_state) {
       else {
         $full_parent = bgimage_get_full_parent($parent);
         if ($full_parent === FALSE) {
-          if ($parent == BG_ID_REQUEST_NID || $parent == BG_FRASS_NID) {
+          if ($parent == BG_ID_REQUEST_NID || $parent == BG_FRASS_NID || $parent == BG_ROOT_NID) {
             $form_state['values']['field_parent'][LANGUAGE_NONE][0]['value'] = $parent;
           }
           else {

--- a/sites/all/modules/custom/bugguide/bugguide.module
+++ b/sites/all/modules/custom/bugguide/bugguide.module
@@ -6,6 +6,9 @@ define('BG_ID_REQUEST_NID', 6);
 // Node ID of Frass
 define('BG_FRASS_NID', 9410);
 
+// Node ID of the root node
+define('BG_ROOT_NID', 3);
+
 /**
  * @file
  * The bugguide module provides bugguide-specific functionality.


### PR DESCRIPTION
I can't see images on images tabs locally because they fetch from solr, but the images I add on node 3 look correct in the db and the tabs on those new image pages point to node 3 when they should, so I think it looks good.