### PR TITLE
#50 Provide a link to a full-sized image based on user role.

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.features.field_instance.inc
+++ b/sites/all/modules/custom/bgimage/bgimage.features.field_instance.inc
@@ -404,12 +404,12 @@ function bgimage_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'hidden',
-        'module' => 'image',
+        'module' => 'bgimage',
         'settings' => array(
           'image_link' => '',
           'image_style' => 'bg_large',
         ),
-        'type' => 'image',
+        'type' => 'bgimage_conditional_link_formatter',
         'weight' => 0,
       ),
       'homepage' => array(

--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -278,6 +278,54 @@ function bgimage_ds_fields_info($entity_type) {
 }
 
 /**
+ * Implements hook_field_formatter_info().
+ */
+function bgimage_field_formatter_info() {
+  $formatters = array(
+    'bgimage_conditional_link_formatter' => array(
+      'label' => t('Image Conditional Link'),
+      'field types' => array('image'),
+      'settings' => array('image_style' => 'bg_large', 'image_link' => ''),
+    ),
+  );
+
+  return $formatters;
+}
+
+/**
+ * Implements hook_field_formatter_view().
+ */
+function bgimage_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
+  $element = array();
+  // Check if the formatter involves a link.
+  if ($display['settings']['image_link'] == 'content') {
+    $uri = entity_uri($entity_type, $entity);
+  }
+  elseif ($entity->type == 'bgimage' && count($items) == 1) {
+    // Provide a link to the fullsize image if either the user created the image
+    // or they have the right permission.
+    global $user;
+    if ($items[0]['uid'] == $user->uid || user_access('view fullsize bgimages')) {
+      $uri = array(
+        'path' => file_create_url($items[0]['uri']),
+        'options' => array(),
+      );
+    }
+  }
+
+  foreach ($items as $delta => $item) {
+    $element[$delta] = array(
+      '#theme' => 'image_formatter',
+      '#item' => $item,
+      '#image_style' => $display['settings']['image_style'],
+      '#path' => isset($uri) ? $uri : '',
+    );
+  }
+
+  return $element;
+}
+
+/**
  * Implements hook_node_validate().
  */
 function bgimage_node_validate($node, $form, &$form_state) {

--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -326,6 +326,20 @@ function bgimage_field_formatter_view($entity_type, $entity, $field, $instance, 
 }
 
 /**
+ * Implements hook_field_formatter_settings_form() by wrapping the default.
+ */
+function bgimage_field_formatter_settings_form($field, $instance, $view_mode, $form, &$form_state) {
+  return image_field_formatter_settings_form($field, $instance, $view_mode, $form,$form_state);
+}
+
+/**
+ * Implements hook_field_formatter_settings_summary() by wrapping the default.
+ */
+function bgimage_field_formatter_settings_summary($field, $instance, $view_mode) {
+  return image_field_formatter_settings_summary($field, $instance, $view_mode);
+}
+
+/**
  * Implements hook_node_validate().
  */
 function bgimage_node_validate($node, $form, &$form_state) {


### PR DESCRIPTION
A user should be able to view a full size image if either:
* their user role has the 'view fullsize bgimages' permission, or
* they created the image.

As suggested at https://github.com/bugguide/bugguide/issues/50#issuecomment-736978382
this was implemented by modifying the image module's version of
hook_field_formatter_view.

Instead of relying on testing $display['settings']['image_link'] == 'file' as in
the image module, which (as far as I can tell) would require making image_link =
'file' the default setting, we instead test for an entity type of bgimage. That
way we can keep the default image_link setting of '' and make our decisions
about full-size viewing knowing that we're only dealing with a bgimage image -
plus a bgimage node should be the only place where it's possible to get a
full-size link of an image (I think), so we want that extra layer of protection
anyway.

bgimage_field_formatter_info was added since bgimage_field_formatter_view would
never be called without hook_field_formatter_info notifying that a formatter is
present in the bgimage module. The hook_field_formatter_info documentation says
"The keys [of the array describing the formatter types implemented by the
module] are formatter type names. To avoid name clashes, formatter type names
should be prefixed with the name of the module that exposes them." - but I was
never able to get bgimage_field_formatter_view to be called using anything other
than a name of 'image'.