### PR TITLE
#183 Format user's additional license info as 'f' during migration.

### DIFF
--- a/sites/all/modules/custom/bgmigrate/bgmigrate.drush.inc
+++ b/sites/all/modules/custom/bgmigrate/bgmigrate.drush.inc
@@ -86,7 +86,7 @@ function drush_bgmigrate_users() {
     $license_details = isset($data['license_details']) ? $data['license_details'] : '';
     if ($license_details) {
       $account->field_user_content_license_add[LANGUAGE_NONE][0]['value'] = $license_details;
-      $account->field_user_biography[LANGUAGE_NONE][0]['format'] = 'f';
+      $account->field_user_content_license_add[LANGUAGE_NONE][0]['format'] = 'f';
     }
     
     // subscriptions_auto


### PR DESCRIPTION
I think that's what we want, and it looks like that's what was intended, just a
copy and paste typo.