### PR TITLE
Allow users to edit their own comments

### DIFF
--- a/sites/all/modules/custom/bg/bg.module
+++ b/sites/all/modules/custom/bg/bg.module
@@ -135,6 +135,37 @@ function bg_permission() {
 }
 
 /**
+ * Implements hook_comment_view_alter().
+ */
+function bg_comment_view_alter(&$build) {
+  if (isset($build['links']['comment']['#links']['comment-edit'])) {
+    if (user_access('administer comments')) {
+      return;
+    }
+    if (_bg_comment_has_replies($build['#comment']->cid)) {
+      unset($build['links']['comment']['#links']['comment-edit']);
+    }
+  }
+
+}
+
+/**
+ * Test whether or not a comment has been replied to.
+ *
+ * @param $cid
+ *   The comment id.
+ * @return
+ *   True if the comment has been replied to.
+ */
+function _bg_comment_has_replies($cid) {
+  $comment_with_pid = db_query('SELECT cid FROM {comment} WHERE pid = :pid AND status = :status', array(
+    ':pid' => $cid,
+    ':status' => COMMENT_PUBLISHED,
+  ))->fetchField();
+  return $comment_with_pid === false ? false : true;
+}
+
+/**
  * Implements hook_filter_info().
  */
 function bg_filter_info() {

--- a/sites/all/modules/custom/bgusers/bgusers.features.user_permission.inc
+++ b/sites/all/modules/custom/bgusers/bgusers.features.user_permission.inc
@@ -983,7 +983,7 @@ function bgusers_user_default_permissions() {
   $permissions['edit own comments'] = array(
     'name' => 'edit own comments',
     'roles' => array(
-      'administrator' => 'administrator',
+      'authenticated user' => 'authenticated user',
     ),
     'module' => 'comment',
   );


### PR DESCRIPTION
This reimplements the functionality removed in https://git.drupalcode.org/project/drupal/-/commit/fea12f8c1d4d4d71176b1a877794e1470ca2b63b

See what you think John, I'm certainly not tied to this solution, I'd be happy to drop this and handle the editing comments issue some other way.

Two notes on the reimplementation:
* I dropped the drupal_static code in the "does this comment have replies" code since I don't see that function ever being called more than once on a page load for the same comment [please correct me though if I'm misunderstanding how that works and you think maybe it could be called more than once];
* I changed the original 'count' query to an exists query; exists is all we care about, and I'd like to believe this: https://blog.jooq.org/2016/09/14/avoid-using-count-in-sql-when-you-could-use-exists/ could make a difference, though that's not clear.