### PR TITLE
Implement 'quiet move' functionality for senior editors

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -122,6 +122,9 @@ function bgimage_permission() {
     'move all bgimages' => array(
       'title' => 'Move all bgimages',
     ),
+    'quiet move all bgimages' => array(
+      'title' => 'Quiet move all bgimages',
+    ),
     'link all bgimages' => array(
       'title' => 'Link bgimage nodes',
     ),

--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -904,7 +904,7 @@ function bgimage_block_view($delta = '') {
 
   $current_node = menu_get_object('node');
   if (!empty($current_node) && in_array($current_node->type, array('bgpage', 'bgimage'))) {
-    $links[] = l(t('<span class="icon is-small"><span class="fa fa-long-arrow-right" aria-hidden="true"></span></span><span>Move'), 'bgimage/move/' . $current_node->nid, array(
+    $links[] = l(t('<span class="icon is-small"><span class="fa fa-long-arrow-right" aria-hidden="true"></span></span><span>Move</span>'), 'bgimage/move/' . $current_node->nid, array(
       'attributes' => array(
         'title' => t('Move these images to the taxonomy of the current page.'),
         'class' => 'clip-move button is-small mr-1 mb-1',
@@ -912,7 +912,7 @@ function bgimage_block_view($delta = '') {
       'html' => TRUE,
     ));
     if (user_access('quiet move all bgimages')) {
-      $links[] = l(t('<span class="icon is-small"><span class="fa fa-long-arrow-right" aria-hidden="true"></span></span><span>Quiet move'), 'bgimage/quiet_move/' . $current_node->nid, array(
+      $links[] = l(t('<span class="icon is-small"><span class="fa fa-long-arrow-right" aria-hidden="true"></span></span><span>Quiet move</span>'), 'bgimage/quiet_move/' . $current_node->nid, array(
         'attributes' => array(
           'title' => t('Quietly move these images to the taxonomy of the current page.'),
           'class' => 'clip-move button is-small mb-1',

--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -62,6 +62,15 @@ function bgimage_menu() {
     'file' => 'bgimage.pages.inc',
   );
 
+  $items['bgimage/quiet_move/%node'] = array(
+    'title' => 'Quietly moves images in the clipboard to the current page',
+    'page callback' => 'bgimage_move_tagged',
+    'page arguments' => array(2, true),
+    'access arguments' => array('quiet move all bgimages'),
+    'type' => MENU_CALLBACK,
+    'file' => 'bgimage.pages.inc',
+  );
+
   $items['bgimage/link'] = array(
     'title' => 'Image tagging',
     'page callback' => 'bgimage_link_tagged',
@@ -875,7 +884,7 @@ function bgimage_block_view($delta = '') {
     $links[] = l(t('<span class="icon is-small"><span class="fa fa-times" aria-hidden="true"></span></span><span>Remove all</span>'), 'bgimage/untag_all', array(
       'attributes' => array(
         'title' => t('Remove these images from the clipboard'),
-        'class' => 'clip-remove-all button is-small mr-1',
+        'class' => 'clip-remove-all button is-small mr-1 mb-1',
         ),
       'query' => array('destination' => current_path()),
       'html' => TRUE,
@@ -886,7 +895,7 @@ function bgimage_block_view($delta = '') {
     $links[] = l(t('<span class="icon is-small"><span class="fa fa-link" aria-hidden="true"></span></span><span>Link</span>'), 'bgimage/link', array(
       'attributes' => array(
         'title' => t('Link together these images of the same specimen.'),
-        'class' => 'clip-link button is-small mr-1',
+        'class' => 'clip-link button is-small mr-1 mb-1',
         ),
       'query' => array('destination' => current_path()),
       'html' => TRUE,
@@ -898,13 +907,22 @@ function bgimage_block_view($delta = '') {
     $links[] = l(t('<span class="icon is-small"><span class="fa fa-long-arrow-right" aria-hidden="true"></span></span><span>Move'), 'bgimage/move/' . $current_node->nid, array(
       'attributes' => array(
         'title' => t('Move these images to the taxonomy of the current page.'),
-        'class' => 'clip-move button is-small',
+        'class' => 'clip-move button is-small mr-1 mb-1',
         ),
       'html' => TRUE,
     ));
+    if (user_access('quiet move all bgimages')) {
+      $links[] = l(t('<span class="icon is-small"><span class="fa fa-long-arrow-right" aria-hidden="true"></span></span><span>Quiet move'), 'bgimage/quiet_move/' . $current_node->nid, array(
+        'attributes' => array(
+          'title' => t('Quietly move these images to the taxonomy of the current page.'),
+          'class' => 'clip-move button is-small mb-1',
+          ),
+        'html' => TRUE,
+      ));
+    }
   }
 
-  $content .= '<div class="panel-block">'. implode(' ', $links) . '</div>';
+  $content .= '<div class="panel-block flex-wrap">'. implode(' ', $links) . '</div>';
 
   return array(
     'subject' => t('Clipboard'),

--- a/sites/all/modules/custom/bgimage/bgimage.pages.inc
+++ b/sites/all/modules/custom/bgimage/bgimage.pages.inc
@@ -69,7 +69,7 @@ function bgimage_untag($node) {
 /**
  * Menu callback. Move an image from the clipboard to this location.
  */
-function bgimage_move_tagged($node) {
+function bgimage_move_tagged($node, $quiet = false) {
   global $user;
 
   $tagged_images = explode(',', $_SESSION['tagged_images']);
@@ -87,6 +87,12 @@ function bgimage_move_tagged($node) {
         // Update parent field for this image.
         $bgimage_wrapper->field_parent->set($path);
         $bgimage_wrapper->save();
+
+        // If we're doing a quiet move then don't produce an autocomment. Moves
+        // to Frass are never quiet.
+        if ($quiet && $node_wrapper->nid != BG_FRASS_NID) {
+          continue;
+        }
 
         // Log a message and leave a comment registering the movement.
         watchdog("bgimage", 'bgimage: moved image @title to path @path', array(

--- a/sites/all/modules/custom/bgusers/bgusers.features.user_permission.inc
+++ b/sites/all/modules/custom/bgusers/bgusers.features.user_permission.inc
@@ -1102,6 +1102,16 @@ function bgusers_user_default_permissions() {
     'module' => 'bgimage',
   );
 
+  // Exported permission: 'quiet move all bgimages'.
+  $permissions['quiet move all bgimages'] = array(
+    'name' => 'quiet move all bgimages',
+    'roles' => array(
+      'administrator' => 'administrator',
+      'senior editor' => 'senior editor',
+    ),
+    'module' => 'bgimage',
+  );
+
   // Exported permission: 'post comments'.
   $permissions['post comments'] = array(
     'name' => 'post comments',

--- a/sites/all/themes/bulmabug/templates/system/block--bgimage--tagged-images.tpl.php
+++ b/sites/all/themes/bulmabug/templates/system/block--bgimage--tagged-images.tpl.php
@@ -50,7 +50,7 @@
 
   <?php print render($title_prefix); ?>
 <?php if ($block->subject): ?>
-  <h2<?php print $title_attributes; ?> class="panel-heading"><span class="icon is-medium"><span class="fa fa-clipboard"></span></span><?php print $block->subject ?></span></h2>
+  <h2<?php print $title_attributes; ?> class="panel-heading"><span class="icon is-medium"><span class="fa fa-clipboard"></span></span><span><?php print $block->subject ?></span></h2>
 <?php endif;?>
   <?php print render($title_suffix); ?>
 


### PR DESCRIPTION
I had to make some small css changes to deal with clipboard buttons overflowing into a second row, so here are some screenshots:
![quiet_move_one](https://user-images.githubusercontent.com/632915/126874736-990c959c-5a05-48f0-be87-913ac304f1dd.jpg)
![quiet_move](https://user-images.githubusercontent.com/632915/126874737-2e6fdc0b-af74-4052-aa8b-82bfaa3ebe9a.jpg)
