### PR TITLE
#231 Return series images ordered by weight in bgimage_get_series.

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -932,7 +932,7 @@ function bgimage_get_series($nid) {
   }
 
   // Next, extract the whole series of nids.
-  $nids = db_query('SELECT nid FROM {bgimage_series} WHERE series = :nid', array(':nid' => $nid))->fetchCol();
+  $nids = db_query('SELECT nid FROM {bgimage_series} WHERE series = :nid ORDER BY weight', array(':nid' => $nid))->fetchCol();
 
   return $nids;
 }


### PR DESCRIPTION
The database won't necessarily return them in that order - which is the order they need to be in - otherwise.