### PR TITLE
Create 'Add book' and 'Add link' buttons for adding new content

### DIFF
--- a/sites/all/modules/custom/bg/bg.module
+++ b/sites/all/modules/custom/bg/bg.module
@@ -165,6 +165,59 @@ function bg_str_ends_with($str, $sub) {
 }
 
 /**
+ * Attempt to set the full parent on a form submission given a potential parent
+ * nid.
+ *
+ * This function assumes the parent form field is named 'field_parent' and calls
+ * form_set_error on that field if the potential parent provided is unsuitable.
+ *
+ * @param array $form_state
+ *   Form state as in hook_node_validate.
+ * @param string $potential_parent
+ *   A potential parent nid (as in '5' if the parent is '3,4,5')
+ */
+function bg_node_validate_set_parent(&$form_state, $potential_parent) {
+  if ($form_state['values']['field_parent'][LANGUAGE_NONE][0]['value'] != '') {
+    return;
+  }
+
+  if (!$potential_parent) {
+    form_set_error('field_parent', 'Unable to continue without a parent.');
+    return;
+  }
+
+  $parent = (int)$potential_parent;
+  if ($parent == 0) {
+    form_set_error('field_parent', "Can't make sense of parent.");
+    return;
+  }
+
+  $full_parent = bg_get_full_parent($parent);
+  if ($full_parent) {
+    $form_state['values']['field_parent'][LANGUAGE_NONE][0]['value'] = $full_parent . ',' . $parent;
+  }
+  else {
+    if ($parent == BG_ID_REQUEST_NID || $parent == BG_FRASS_NID || $parent == BG_ROOT_NID) {
+      $form_state['values']['field_parent'][LANGUAGE_NONE][0]['value'] = $parent;
+    }
+    else {
+      form_set_error('field_parent', 'No such parent.');
+    }
+  }
+}
+
+/**
+ * Given a nid return a comma-delimited string of parents.
+ *
+ * @param int $nid
+ * @return string e.g., 52,124,2234,32234
+ */
+function bg_get_full_parent($nid) {
+  $parent = db_query("SELECT field_parent_value FROM {field_data_field_parent} WHERE entity_id = :nid", array(':nid' => $nid))->fetchField();
+  return $parent;
+}
+
+/**
  * Build a one-line taxonomic linked breadcrumb.
  *
  * @param object $node

--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -346,36 +346,11 @@ function bgimage_node_validate($node, $form, &$form_state) {
   if ($node->type != 'bgimage') {
     return;
   }
-  // Need a bg_str_ends_with from bg.module
+
   drupal_load('module', 'bg');
 
-  // Set parent.
-  if ($form_state['values']['field_parent'][LANGUAGE_NONE][0]['value'] == '') {
-    $potential_parent = arg(3); // node/add/bgimage/1234
-    if ($potential_parent === NULL) {
-      form_set_error('field_bgimage_parent', 'bgimage is unable to continue without a parent.');
-    }
-    else {
-      $parent = (int)$potential_parent;
-      if ($parent == 0) {
-        form_set_error('field_bgimage_parent', 'bgimage could not make sense of parent.');
-      }
-      else {
-        $full_parent = bgimage_get_full_parent($parent);
-        if ($full_parent === FALSE) {
-          if ($parent == BG_ID_REQUEST_NID || $parent == BG_FRASS_NID || $parent == BG_ROOT_NID) {
-            $form_state['values']['field_parent'][LANGUAGE_NONE][0]['value'] = $parent;
-          }
-          else {
-            form_set_error('field_parent', 'bgimage: No such parent.');
-          }
-        }
-        else {
-          $form_state['values']['field_parent'][LANGUAGE_NONE][0]['value'] = $full_parent . ',' . $parent;
-        }
-      }
-    }
-  }
+  // Attempt to set the full parent based on our calling nid.
+  bg_node_validate_set_parent($form_state, arg(3));
 
   if ($node->{'field_bgimage_image'}[LANGUAGE_NONE][0]['fid'] == 0) {
     form_set_error('field_bgimage_image', 'Did you forget to attach an image? Please attach one and resubmit.');
@@ -805,17 +780,6 @@ function bgimage_original_from_derivative_path($scheme, $target) {
 
   return $scheme . '://' . 'raw/' . $prefix . $obfuscated . '.jpg';
   // public://raw/ELI/RTZ/ELIRTZ8RTL8RZH4ROLXZALIZNLYLCZQRYZMRFZ0RCZIROZRZCLMZRH0RFZFL3ZRZOZ.jpg
-}
-
-/**
- * Given a nid return a comma-delimited string of parents.
- *
- * @param int $nid
- * @return string e.g., 52,124,2234,32234
- */
-function bgimage_get_full_parent($nid) {
-  $parent = db_query("SELECT field_parent_value FROM {field_data_field_parent} WHERE entity_id = :nid", array(':nid' => $nid))->fetchField();
-  return $parent;
 }
 
 /**

--- a/sites/all/modules/custom/bglink/bglink.module
+++ b/sites/all/modules/custom/bglink/bglink.module
@@ -33,3 +33,17 @@ function bglink_menu() {
 
   return $items;
 }
+
+/**
+ * Implements hook_node_validate().
+ */
+function bglink_node_validate($node, $form, &$form_state) {
+  if ($node->type != 'bglink') {
+    return;
+  }
+
+  drupal_load('module', 'bg');
+
+  // Attempt to set the full parent based on our calling nid.
+  bg_node_validate_set_parent($form_state, arg(3));
+}

--- a/sites/all/modules/custom/bglink/bglink.module
+++ b/sites/all/modules/custom/bglink/bglink.module
@@ -15,3 +15,21 @@ function bglink_views_query_alter(&$view, &$query) {
     _bgpage_views_query_alter_for_field_parent($view, $query);
   }
 }
+
+/**
+ * Implements hook_menu().
+ */
+function bglink_menu() {
+  $items = array();
+
+  $items['node/%bgpage_node/bglink/add'] = array(
+    'title' => 'Add link',
+    'page callback' => 'bglink_add_link',
+    'page arguments' => array(1),
+    'access arguments' => array('create bglink content'),
+    'type' => MENU_LOCAL_ACTION,
+    'file' => 'bglink.pages.inc',
+  );
+
+  return $items;
+}

--- a/sites/all/modules/custom/bglink/bglink.pages.inc
+++ b/sites/all/modules/custom/bglink/bglink.pages.inc
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Page callbacks for the bglink module.
+ */
+
+/**
+ * Redirects to a form to add a link for a bgpage.
+ *
+ * @param int $nid
+ *   The nid of the bgpage node.
+ */
+function bglink_add_link($nid) {
+  drupal_goto('node/add/bglink/' . $nid);
+}

--- a/sites/all/modules/custom/bgref/bgref.module
+++ b/sites/all/modules/custom/bgref/bgref.module
@@ -33,3 +33,17 @@ function bgref_menu() {
 
   return $items;
 }
+
+/**
+ * Implements hook_node_validate().
+ */
+function bgref_node_validate($node, $form, &$form_state) {
+  if ($node->type != 'book_reference') {
+    return;
+  }
+
+  drupal_load('module', 'bg');
+
+  // Attempt to set the full parent based on our calling nid.
+  bg_node_validate_set_parent($form_state, arg(3));
+}

--- a/sites/all/modules/custom/bgref/bgref.module
+++ b/sites/all/modules/custom/bgref/bgref.module
@@ -15,3 +15,21 @@ function bgref_views_query_alter(&$view, &$query) {
     _bgpage_views_query_alter_for_field_parent($view, $query);
   }
 }
+
+/**
+ * Implements hook_menu().
+ */
+function bgref_menu() {
+  $items = array();
+
+  $items['node/%bgpage_node/bgref/add'] = array(
+    'title' => 'Add book',
+    'page callback' => 'bgref_add_ref',
+    'page arguments' => array(1),
+    'access arguments' => array('create book_reference content'),
+    'type' => MENU_LOCAL_ACTION,
+    'file' => 'bgref.pages.inc',
+  );
+
+  return $items;
+}

--- a/sites/all/modules/custom/bgref/bgref.pages.inc
+++ b/sites/all/modules/custom/bgref/bgref.pages.inc
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Page callbacks for the bgref module.
+ */
+
+/**
+ * Redirects to a form to add a book reference for a bgpage.
+ *
+ * @param int $nid
+ *   The nid of the bgpage node.
+ */
+function bgref_add_ref($nid) {
+  drupal_goto('node/add/book-reference/' . $nid);
+}

--- a/sites/all/themes/bulmabug/css/bulma-bug.css
+++ b/sites/all/themes/bulmabug/css/bulma-bug.css
@@ -621,6 +621,8 @@ a:hover,
 
 /* + Add images (of this individual) */
 .page-node-bgimage .action-links a:before,
+.page-node-bgref .action-links a:before,
+.page-node-bglink .action-links a:before,
 .node-type-bgimage .action-links a:before {
   content: '\f067'; /* fa-plus */
   font-family: 'FontAwesome';
@@ -634,7 +636,9 @@ a:hover,
   font-size: 0.75rem;
 }
 
-.page-node-bgimage .action-links a {
+.page-node-bgimage .action-links a,
+.page-node-bgref .action-links a,
+.page-node-bglink .action-links a {
   margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
Screenshots of the new buttons:
![book_link](https://user-images.githubusercontent.com/632915/126912326-fe2f22bc-521f-46cb-af47-21d67df827bc.jpg)
![link_link](https://user-images.githubusercontent.com/632915/126912328-1098f31b-0a37-4cef-802d-4e2feb517cb1.jpg)
I checked in the database that the parent field is being set correctly using the new buttons (for bgref/bglink, and bgimage), but something's off with display of books and links - for example a book or ref added on node 5 (with parent 3,4,5) doesn't show up on the book/refs tab on node 5 (where I'd expect it), but it does show up on nodes 3 and 4 (where I wouldn't expect it)...