### PR TITLE
#236 Don't sort by the Title column in the bgrefs view.

### DIFF
--- a/sites/all/modules/custom/bgref/bgref.views_default.inc
+++ b/sites/all/modules/custom/bgref/bgref.views_default.inc
@@ -36,7 +36,7 @@ function bgref_views_default_views() {
     'title' => 'title',
     'field_book_reference_author' => 'field_book_reference_author',
   );
-  $handler->display->display_options['style_options']['default'] = 'title';
+  $handler->display->display_options['style_options']['default'] = '-1';
   $handler->display->display_options['style_options']['info'] = array(
     'nid' => array(
       'sortable' => 1,


### PR DESCRIPTION
To make this change I went to http://bugguide.test/#overlay=admin/structure/views/view/all_books/edit/by_bgpage, clicked on the Books tab, then clicked on Format: Settings, and clicked the radio button for None in the 'Default sort' column, then saved everything, exported the bgref feature, and diffed to find the right line to change and what to change it to.