### PR TITLE
#238 Include refs and links whose parent is the current node.

### DIFF
--- a/sites/all/modules/custom/bgpage/bgpage.module
+++ b/sites/all/modules/custom/bgpage/bgpage.module
@@ -597,7 +597,8 @@ function bgpage_fetch_classification($nid, $filter) {
  * '3,878075,52,57,81',
  * '3,878075,52,57,81,156',
  * '3,878075,52,57,81,156,43480',
- * '3,878075,52,57,81,156,43480,483723')) OR (field_parent_value LIKE '3,878075,52,57,81,156,43480,483723,347,%' ESCAPE '\\') ) AND
+ * '3,878075,52,57,81,156,43480,483723,
+ * '3,878075,52,57,81,156,43480,483723,347')) OR (field_parent_value LIKE '3,878075,52,57,81,156,43480,483723,347,%' ESCAPE '\\') ) AND
  * (( (node.status = '1') AND (node.type IN  ('book_reference')) AND (field_data_field_parent.field_parent_value LIKE '%' ESCAPE '\\') )))
  * ORDER BY field_parent_value != '3,878075,52,57,81,156,43480,483723,347', LENGTH(field_parent_value) DESC, node_created DESC
  * LIMIT 25 OFFSET 0
@@ -612,12 +613,16 @@ function bgpage_fetch_classification($nid, $filter) {
  * @see bglink.module
  */
 function _bgpage_views_query_alter_for_field_parent(&$view, &$query) {
-  $node = node_load($view->args[0]);
+  $nid = $view->args[0];
+  $node = node_load($nid);
   if (!isset($node->field_parent[LANGUAGE_NONE][0]['value'])) {
     return;
   }
   $parent_paths = array();
-  $parent_path = $node->field_parent[LANGUAGE_NONE][0]['value'];
+  // We want to include refs/links whose parent is this node - in fact we want
+  // to prioritize those - so include this node in the parent path.
+  $parent_path = $node->field_parent[LANGUAGE_NONE][0]['value'] . ',' . $nid;
+
   $parent = '';
   foreach (explode(',', $parent_path) as $nid) {
     if ($parent) {
@@ -636,15 +641,18 @@ function _bgpage_views_query_alter_for_field_parent(&$view, &$query) {
       ),
       array(
         'field' => 'field_parent_value',
-        'value' => $parent_path . ',' . $node->nid . ',%',
+        'value' => $parent_path . ',%',
         'operator' => 'LIKE',
       )
     ),
     'type' => 'OR',
   );
   array_unshift($query->where, $where_condition);
+
+  // The following is equivalent to:
+  // ORDER BY field_parent_value != '$parent_path' ASC, LENGTH(field_parent_value) DESC
   $order_by = array(
-    'field' => "field_parent_value != '$parent_path,$node->nid', LENGTH(field_parent_value)",
+    'field' => "field_parent_value != '$parent_path', LENGTH(field_parent_value)",
     'direction' => 'DESC',
   );
   array_unshift($query->orderby, $order_by);


### PR DESCRIPTION
Currently we're including all refs or links whose parent is strictly above or stricly below the current node.