### PR TITLE
#213 Display 'Page not found' for bgmap tabs on non-existent nodes.

### DIFF
--- a/sites/all/modules/custom/bgmap/bgmap.pages.inc
+++ b/sites/all/modules/custom/bgmap/bgmap.pages.inc
@@ -158,6 +158,9 @@ function bgmap_page($nid) {
   }
   
   $node = node_load($nid);
+  if (!$node) {
+    return MENU_NOT_FOUND;
+  }
   drupal_add_js('https://calc.bugwoodcloud.org/static/js/iframe.js', 'external');
   $output = '<div id="iframecontainer"><iframe src="https://maps.eddmaps.org/bugguidestate/?node=' . $node->nid . '" frameborder="0" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" height="500" width="960" scrolling="no" seamless></iframe></div>';
   $output .= '<div id="iframecontainer"><iframe src="https://maps.eddmaps.org/bugguide/?node=' . $node->nid . '" frameborder="0" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true" height="500" width="960" scrolling="no" seamless></iframe></div>';


### PR DESCRIPTION
I wasn't tuned into bgmap yet when I added the other no-node checks in #215; this (bgmap) should be the last one.