### PR TITLE
#181 Add keyboard shortcuts for pager previous/next page links.

### DIFF
--- a/sites/all/themes/bulmabug/template.php
+++ b/sites/all/themes/bulmabug/template.php
@@ -53,3 +53,46 @@ function bulmabug_preprocess_views_view_table(&$vars) {
 function bulmabug_preprocess_comment(&$variables) {
     $variables['submitted'] = '&ndash;&nbsp;' . t('!username, !datetime', array('!username' => $variables['author'], '!datetime' => format_date(strtotime($variables['created']), 'custom', 'j F, Y  -  h:i a')));
 }
+
+/**
+ * Implements hook_preprocess_HOOK.
+ */
+function bulmabug_preprocess_item_list(&$vars) {
+  if (!in_array('pager', $vars['attributes']['class']) || !isset($vars['items'])) {
+    return;
+  }
+
+  // Replace the default pager link titles with hints that users can use their
+  // keyboard to go to the previous or next page.
+  foreach ($vars['items'] as &$item) {
+    if (isset($item['class']) && in_array('pager-previous', $item['class'])) {
+      $item['data'] = str_replace('Go to previous page', 'Or use your left-arrow key', $item['data']);
+      continue;
+    }
+    if (isset($item['class']) && in_array('pager-next', $item['class'])) {
+      $item['data'] = str_replace('Go to next page', 'Or use your right-arrow key', $item['data']);
+      continue;
+    }
+  }
+
+  // Add a key event listener so users can use left and right arrows to navigate pagers.
+  $event_listener = <<<'EOD'
+      document.addEventListener("keyup", function(e) {
+        // Ignore modifier keys.
+        if (e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) return;
+        if (e.which == 37) {
+          prev = document.querySelector(".pager>.pager-previous>a");
+          if (prev) prev.click();
+        } else if (e.which == 39) {
+          next = document.querySelector(".pager>.pager-next>a");
+          if (next) next.click();
+        }
+      });
+EOD;
+
+  drupal_add_js($event_listener, array(
+      'type' => 'inline',
+      'scope' => 'footer',
+      'weight' => 0,
+    ));
+}

--- a/sites/all/themes/bulmabug/template.php
+++ b/sites/all/themes/bulmabug/template.php
@@ -66,11 +66,11 @@ function bulmabug_preprocess_item_list(&$vars) {
   // keyboard to go to the previous or next page.
   foreach ($vars['items'] as &$item) {
     if (isset($item['class']) && in_array('pager-previous', $item['class'])) {
-      $item['data'] = str_replace('Go to previous page', 'Or use your left-arrow key', $item['data']);
+      $item['data'] = str_replace('Go to previous page', 'Go to previous page (or use your left-arrow key)', $item['data']);
       continue;
     }
     if (isset($item['class']) && in_array('pager-next', $item['class'])) {
-      $item['data'] = str_replace('Go to next page', 'Or use your right-arrow key', $item['data']);
+      $item['data'] = str_replace('Go to next page', 'Go to next page (or use your right-arrow key)', $item['data']);
       continue;
     }
   }


### PR DESCRIPTION
Locally I tested on pagers on the homepage, on recent images, and on a links tab with multiple pages; I'll have to wait until/if this reaches beta to test some of the other pages that could have pagers.