### PR TITLE
#122 Take value() of nid in quiet move EntityMetadataWrapper.

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.pages.inc
+++ b/sites/all/modules/custom/bgimage/bgimage.pages.inc
@@ -90,7 +90,7 @@ function bgimage_move_tagged($node, $quiet = false) {
 
         // If we're doing a quiet move then don't produce an autocomment. Moves
         // to Frass are never quiet.
-        if ($quiet && $node_wrapper->nid != BG_FRASS_NID) {
+        if ($quiet && $node_wrapper->nid->value() != BG_FRASS_NID) {
           continue;
         }
 


### PR DESCRIPTION
$node_wrapper->nid has type EntityValueWrapper, not int.