### PR TITLE
#219 Set comments on images to 'Preview optional'.

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.strongarm.inc
+++ b/sites/all/modules/custom/bgimage/bgimage.strongarm.inc
@@ -50,7 +50,7 @@ function bgimage_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'comment_preview_bgimage';
-  $strongarm->value = '2';
+  $strongarm->value = '1';
   $export['comment_preview_bgimage'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
Users can now edit their own comments, so preview isn't required.