### PR TITLE
#265 Don't use grid for the County label in the image submission form.

### DIFF
--- a/sites/all/themes/bulmabug/css/bulma-bug.css
+++ b/sites/all/themes/bulmabug/css/bulma-bug.css
@@ -784,3 +784,10 @@ a:hover,
 .bg-image-list .column {
     padding: 0.15rem;
 }
+
+@media screen and (min-width: 1024px) {
+  /* Override bulma to account for the long label of the county field. */
+  #field-bgimage-county-add-more-wrapper .form-type-textfield {
+    display: block;
+  }
+}


### PR DESCRIPTION
The label is too long to fit in the fixed-width grid box, so instead we override bulma's CSS for text inputs in node forms on large screens to display the label and input the same way it would appear on a narrower screen (or in the admin theme): with the label on the line above the input, with no space in between.