### PR TITLE
#271 Add vertical spacing between the two related-action buttons on n…

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.ds.field.inc
+++ b/sites/all/modules/custom/bgimage/bgimage.ds.field.inc
@@ -120,7 +120,7 @@ function _bgimage_field_related_images($field) {
     return;
   }
 
-  $output = '<div class="bgimage-related-actions mb-2">';
+  $output = '<div class="bgimage-related-actions">';
   if (user_access('use image clipboard')) {
     $output .= l(
       t('Add all images to clipboard'),

--- a/sites/all/themes/bulmabug/css/bulma-bug.css
+++ b/sites/all/themes/bulmabug/css/bulma-bug.css
@@ -659,6 +659,10 @@ a:hover,
   content: '\f127';
 }
 
+.bgimage-related-actions a {
+  margin-bottom: 0.75rem;
+}
+
 /* --------------------- */
 /* ## GUIDE PAGE
 /* --------------------- */


### PR DESCRIPTION
…arrow screens.

On narrow screens instead of being side by side they're stacked. The distance between the 'Add to clipboard' button and the related actions div is 0.75rem, so I think the only stacked distance between the two related actions buttons that looks good is 0.75rem.  With this fix that changes the distance from the bottom of the related actions button(s) to the next field to be 0.75rem instead of the 0.5rem that it was previously.