### PR TITLE
#324 Define the 'error' class for use in form error reporting.

### DIFF
--- a/sites/all/themes/bulma/css/bulma-custom.css
+++ b/sites/all/themes/bulma/css/bulma-custom.css
@@ -574,6 +574,12 @@ label {
   font-size: 0.9em;
 }
 
+.form-item input.error,
+.form-item textarea.error,
+.form-item select.error {
+  border: 2px solid #ed541d;
+}
+
 /* --- Filter Wrapper --- */
 
 .filter-wrapper {


### PR DESCRIPTION
Copied these classes from system.theme.css, with the color changed from 'red' to the border color used for drupal_set_message errors, which (as currently used) is defined by system.theme.css.

I think this covers our current use cases, but it doesn't work on checkboxes or radio inputs (which I guess are difficult to style).