### PR TITLE
#281 Honor an empty date when creating a cloned image.

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -1052,6 +1052,17 @@ function bgimage_form_bgimage_node_form_alter(&$form, &$form_state) {
     $form['field_bgimage_base']['#access'] = FALSE;
   }
 
+  // If this is a cloned node and the original node had no date set, then do the
+  // same for this node (otherwise today's date is used as a default).
+  if (isset($form['clone_from_original_nid']['#value'])) {
+    $original_nid = $form['clone_from_original_nid']['#value'];
+    $original_node = node_load($original_nid);
+    if ($original_node && !$original_node->field_bgimage_date) {
+      unset($form['field_bgimage_date'][LANGUAGE_NONE][0]['#default_value']);
+      $form['field_bgimage_date'][LANGUAGE_NONE][0]['#default_value'] = array('value' => '');
+    }
+  }
+
   // Add a second submit button which allows the user to apply (most of) the
   // settings in the current form to all images in this series, but only if
   // we're currently cloning an image or this image is already one in a series.


### PR DESCRIPTION
Without this patch if you clone an image with an empty date, the current date is inserted in the date field of the cloned node create node form.

The cloned node in this case correctly has an empty field_bgimage_date, but it seems the form creation code in the clone case inserts a default date in that case (I'm not sure why it only happens on cloned nodes and not when editing an existing node with no date field set; maybe just using a different form generation path in the two cases?). The #default_value being set here is the same as that seen on the edit form of an existing node with no date set.