### PR TITLE
#341 Don't show 'Clone of' in the title of cloned nodes.

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -862,6 +862,7 @@ function bgimage_clone_node_alter(&$node, $context) {
     $node->field_bgimage_image = array(LANGUAGE_NONE => array());
     // Remove "Clone of".
     $node->title = str_replace('Clone of ', '', $node->title);
+    drupal_set_title($node->title);
     // Add the original nid in order to update bgimage_series.
     $base_nid = _bgimage_get_series_base($context['original_node']->nid);
     $node->original_nid = $base_nid ? $base_nid : $context['original_node']->nid;


### PR DESCRIPTION
node_clone has already set the title by the time our alter hook gets called: https://github.com/bugguide/bugguide/blob/5030d564dd347b44422b0876fe8deb4f8e4f8d1f/sites/all/modules/node_clone/clone.pages.inc#L176-L179 so we just need to set the title again after we've updated it.