### PR TITLE
#335 Check for a living being on the user register form.

### DIFF
--- a/sites/all/modules/custom/bguserfields/bguserfields.module
+++ b/sites/all/modules/custom/bguserfields/bguserfields.module
@@ -130,6 +130,38 @@ function bguserfields_form_user_register_form_alter(&$form, &$form_state, $form_
   if (isset($form['field_user_breadcrumb_format']['#access'])) {
     $form['field_user_breadcrumb_format']['#access'] = FALSE;
   }
+
+  // Add a simple check to make sure it's a person submitting the form.
+  $form['sitename'] = array(
+    '#type' => 'textfield',
+    '#required' => TRUE,
+    '#description' => 'To prove that you are a living being and not software, enter the name of this site which you can find at the upper left of this page, <b>then an exclamation mark</b>.',
+    '#weight' => 20,
+    '#title' => t('Site'),
+    '#title_display' => 'invisible',
+    '#attributes' => array('placeholder' => t('Site')),
+  );
+
+  $form['#validate'][] = '_bguserfields_validate_user_register_form';
+}
+
+function _bguserfields_validate_user_register_form($form, $form_state) {
+  if (strtoupper($form_state['values']['sitename']) == 'BUGGUIDE!') {
+    return;
+  }
+
+  // If form submission failed because the username or email already exists then
+  // assume we're dealing with a human and give them another try on the site
+  // name; otherwise we assume it's a bot and redirect.
+  $form_errors = form_get_errors();
+  $name_is_taken = isset($form_errors['name']) && strpos($form_errors['name'], 'is already taken') !== FALSE;
+  $mail_is_taken = isset($form_errors['mail']) && strpos($form_errors['mail'], 'is already registered') !== FALSE;
+  if ($name_is_taken || $mail_is_taken) {
+    form_set_error('sitename', t('Please input the site name as described in the instructions.'));
+    return;
+  }
+
+  drupal_goto('help', array('reg' => 'n'));
 }
 
 /**


### PR DESCRIPTION
I've tried to duplicate the current BugGuide behavior here, which as far as I can tell is:
* if form submission fails because the username or email is already taken, then give the user another try;
* otherwise redirect to the help page (which doesn't exist on bg7 yet), I guess to make it harder for bots to try again?

Unfortunately this means we have to try to check the error messages set by the system to detect why system validation failed (this will probably need more work if we ever translate to other languages).

The redirect will currently 404 since we don't have a /help page yet.

Note that we set the title on the 'Site' field using the placeholder attribute, following the practice of the other fields on this form, but then also set an invisible actual title because of https://github.com/bugguide/bugguide/blob/5030d564dd347b44422b0876fe8deb4f8e4f8d1f/includes/form.inc#L1452-L1462
"// Although discouraged, a #title is not mandatory for form elements. In
 // case there is no #title, we cannot set a form error message.
 // Instead of setting no #title, form constructors are encouraged to set
 // #title_display to 'invisible' to improve accessibility."