### PR TITLE
#358 Use the correct title when checking for existing guide pages.

### DIFF
--- a/sites/all/modules/custom/bgpage/bgpage.module
+++ b/sites/all/modules/custom/bgpage/bgpage.module
@@ -263,6 +263,9 @@ function bgpage_node_form_validate(&$form, &$form_state) {
 
   $scientific_name = NULL;
 
+  // Make sure we're using clean common and scientific names.
+  $form_state['values']['field_scientific_name'][LANGUAGE_NONE][0]['value'] = trim($form_state['values']['field_scientific_name'][LANGUAGE_NONE][0]['value']);
+  $form_state['values']['field_common_name'][LANGUAGE_NONE][0]['value'] = trim($form_state['values']['field_common_name'][LANGUAGE_NONE][0]['value']);
   $values = $form_state['values'];
 
   if (!isset($TAXON_NAMES[$values['field_taxon'][LANGUAGE_NONE][0]['value']])) {
@@ -273,34 +276,35 @@ function bgpage_node_form_validate(&$form, &$form_state) {
   }
 
   if ($taxon_name == t('No Taxon')) {
-    // TODO this should really hide the field in form_alter()
-
     // Check if this is a duplicate entry.
-    // TODO update for D7
-    //$nid = db_result(db_query("SELECT n.nid FROM {node} n JOIN {bgpage} p ON p.nid = n.nid WHERE n.title = '%s' AND p.parent = '%s' AND n.nid != %d", $node->title, $node->parent, $node->nid));
-    // Criteria: has same parent, also has same title, also is not this node (if editing)
-    $query = new EntityFieldQuery;
-    $query->entityCondition('entity_type', 'node')
-          ->entityCondition('bundle', 'bgpage')
-          ->propertyCondition('title', $values['title'])
-          ->fieldCondition('field_parent', 'value', $values['field_parent'][LANGUAGE_NONE][0]['value']);
-    // Existing nodes have nids.
-    // In that case we want the query to exclude the nid of this node
-    // because it is silly to alert that this node has the same title as this node.
-    if (isset($values['nid'])) {
-      $query->propertyCondition('nid', $values['nid'], '<>');
-    }
-    $result = $query->execute();
-    if (!empty($result['node'])) {
-      foreach ($result['node'] as $nid => $info) {
-        form_set_error('', t('There is a <a href="!link" target="_blank">guide page</a> with that title and parent.', array(
-          '!link' => url('node/' . $nid),
-        )));
+    // Criteria: has same parent, also has same title, also is not this node (if editing).
+    // The title for a No Taxon node is the common name; if it doesn't exist
+    // then we'll fail validation when we validate the common name below.
+    if ($values['field_common_name'][LANGUAGE_NONE][0]['value']) {
+      $title = $values['field_common_name'][LANGUAGE_NONE][0]['value'];
+      $query = new EntityFieldQuery;
+      $query->entityCondition('entity_type', 'node')
+            ->entityCondition('bundle', 'bgpage')
+            ->propertyCondition('title', $title)
+            ->fieldCondition('field_parent', 'value', $values['field_parent'][LANGUAGE_NONE][0]['value']);
+      // Existing nodes have nids.
+      // In that case we want the query to exclude the nid of this node
+      // because it is silly to alert that this node has the same title as this node.
+      if (isset($values['nid'])) {
+        $query->propertyCondition('nid', $values['nid'], '<>');
+      }
+      $result = $query->execute();
+      if (!empty($result['node'])) {
+        foreach ($result['node'] as $nid => $info) {
+          form_set_error('', t('There is a <a href="!link" target="_blank">guide page</a> with that title and parent.', array(
+            '!link' => url('node/' . $nid),
+          )));
+        }
       }
     }
   }
   elseif (isset($values['field_scientific_name'][LANGUAGE_NONE][0]['value'])) {
-    $scientific_name = trim($values['field_scientific_name'][LANGUAGE_NONE][0]['value']);
+    $scientific_name = $values['field_scientific_name'][LANGUAGE_NONE][0]['value'];
     if (!$scientific_name) {
       form_set_error('field_scientific_name', t('You must specify a scientific name.'));
     }
@@ -369,10 +373,14 @@ function bgpage_node_form_validate(&$form, &$form_state) {
   // Common name field is required, as it becomes the node title.
   // If it has not been entered by the user, build it.
   if ($values['field_common_name'][LANGUAGE_NONE][0]['value'] == '') {
-    // Populating a common name for Species and Subspecies includes the Genus name.
-    // E.g., 1668198 is a subspecies so even though the scientific name is nevadensis
-    // the common name value would be Zootermopsis nevadensis nevadensis.
-    if (($taxon_name == "Species") || ($taxon_name == "Subspecies")) {
+    if ($taxon_name == t('No Taxon')) {
+      form_set_error('field_common_name', t('A common name is required for No Taxon pages.'));
+    }
+    elseif (($taxon_name == "Species") || ($taxon_name == "Subspecies")) {
+      // Populating a common name for Species and Subspecies includes the Genus
+      // name. E.g., 1668198 is a subspecies so even though the scientific name
+      // is nevadensis the common name value would be Zootermopsis nevadensis
+      // nevadensis.
       $nids = explode(',', $values['field_parent'][LANGUAGE_NONE][0]['value']);
       if (isset($values['nid'])) {
         $nids = array_merge($nids, array($values['nid']));


### PR DESCRIPTION
The form 'title' input is intentionally hidden: https://github.com/bugguide/bugguide/blob/0a6766d242f5029934a49ea8e8eb4368fed63bf7/sites/all/modules/custom/bgpage/bgpage.module#L238-L241 since we're going to set it by hand to what we want at the end of the validator (after the issue we're fixing here occurs).

This patch also validates that a common name is set if this is a No Taxon node.