### PR TITLE
#367 Add a 'Recent images' action for displaying recent images for a …

### DIFF
--- a/sites/all/modules/custom/bg/bg.module
+++ b/sites/all/modules/custom/bg/bg.module
@@ -494,9 +494,13 @@ function bg_preprocess_page(&$vars) {
 
     if (isset($node->type) && in_array($node->type, array('bgpage', 'bgimage'))) {
       list($title_no_markup, $title_markup) = _bg_get_title_classification($node);
+      if ($node->type == 'bgpage' && drupal_get_title() == 'Recent Images Placed in ') {
+        $title_no_markup = 'Recent Images Placed in ' . $title_no_markup;
+        $title_markup = 'Recent Images Placed in ' . $title_markup;
+      }
       // Sets the title bar title; we override the node title below.
       drupal_set_title($title_no_markup);
-      // drupal_set_title doesn't handle markup, so as a hack workaround we
+      // drupal_set_title doesn't handle markup, so as a workaround we
       // set the markup title here instead - from here it will be passed
       // directly to our page template instead of going through
       // drupal_set_title.

--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -113,6 +113,15 @@ function bgimage_menu() {
     'file' => 'bgimage.pages.inc',
   );
 
+  $items['node/%bgpage_node/bgimage/recent'] = array(
+    'title' => 'Recent images',
+    'page callback' => 'bgimage_recent',
+    'page arguments' => array(1),
+    'access arguments' => array('access content'),
+    'type' => MENU_LOCAL_ACTION,
+    'file' => 'bgimage.pages.inc',
+  );
+
   return $items;
 }
 

--- a/sites/all/modules/custom/bgimage/bgimage.pages.inc
+++ b/sites/all/modules/custom/bgimage/bgimage.pages.inc
@@ -248,3 +248,67 @@ function bgimage_unlink_image_series($nid) {
 function bgimage_add_image($nid) {
   drupal_goto('node/add/bgimage/' . $nid);
 }
+
+/**
+ * Display a pager of all of the images of this node and all of its
+ * descendants, ordered by date submitted and formatted in teaser form.
+ *
+ * @param $nid
+ *   The image listing will be restricted to this node and its descendants.
+ */
+function bgimage_recent($nid) {
+  $nid = (int) $nid;
+  if (!$nid) {
+    drupal_goto('<front>');
+  }
+
+  $parent = node_load($nid);
+  if (!$parent || $parent->type != 'bgpage') {
+    watchdog('bgimage', "bgimage_recent() cannot load node nid '%nid'", array('%nid' => $nid), WATCHDOG_ERROR);
+    drupal_goto('<front>');
+  }
+
+  // The title will be completed in bg_preprocess_page, where a markuped taxon
+  // will be added.
+  drupal_set_title(t('Recent Images Placed in '));
+
+  $path = isset($parent->field_parent[LANGUAGE_NONE][0]['value']) ? $parent->field_parent[LANGUAGE_NONE][0]['value'] : '';
+  $path = $path ? $path . ',' . $nid : $nid;
+
+  $query = db_select('node', 'n')->extend('PagerDefault');
+  $query->addField('n', 'nid');
+  $query->join('field_data_field_parent', 'p', 'n.nid = p.entity_id');
+  $query->condition('n.type', 'bgimage')
+        ->condition('n.status', 1)
+        ->condition('p.field_parent_value', $path . '%', 'LIKE')
+        ->orderBy('n.created', 'DESC');
+
+  // Behind the scenes PagerDefault has added a limit and offset to our query
+  // (partly based on any 'page' query parameter in the current url) - get the
+  // current batch of nids.
+  $result = $query->execute();
+
+  $output = '';
+  $images_found = FALSE;
+  foreach ($result as $record) {
+    $node = node_load($record->nid);
+    if (!$node) {
+      continue;
+    }
+    $node_array = node_view($node, 'teaser');
+    $output .= drupal_render($node_array);
+    $images_found = TRUE;
+  }
+
+  if ($images_found) {
+    // TODO: a feed for every taxon.
+    // $feed_url = url('rss.xml', array('absolute' => TRUE));
+    // drupal_add_feed($feed_url, variable_get('site_name', 'Drupal') .' '. t('RSS'));
+    $output .= '<p>' . theme('pager') . '</p>';
+  }
+  else {
+    $output .= '<br>There are currently no images to display here.';
+  }
+
+  return $output;
+}

--- a/sites/all/themes/bulmabug/css/bulma-bug.css
+++ b/sites/all/themes/bulmabug/css/bulma-bug.css
@@ -630,6 +630,16 @@ a:hover,
   margin-right: 0.5rem;
 }
 
+.page-node-bgimage .action-links li {
+  display: inline;
+}
+
+/* The Recent images button */
+
+.page-node-bgimage .action-links li:nth-child(2) a:before {
+  content: '\f061'; /* fa-arrow-right */
+}
+
 .node-type-bgimage .action-links a {
   /* is-small */
   border-radius: 2px;


### PR DESCRIPTION
…taxon

'options' on a MENU_LOCAL_ACTION are ignored (according to the docs), and my initial attempts at adding a CSS class for the action using various hooks failed, so we're just doing it in CSS directly.

My (vague) understanding is that in order for a local action to display on a given page, the path of the action must extend the path of the page (or something along those lines); so here our recent taxon images action path, 'node/%bgpage_node/bgimage/recent', extends the images tab path 'node/%bgpage_node/bgimage'. (This is a different path than what current BugGuide uses for recent taxon images.)

The title we were setting in our new action was being overwritten by bg_preprocess_page; as it turns out, if we want our taxon name to be markuped then the place it was being overwritten is the only place it can be set anyway, and the title being set there is the non-constant part of the title we wanted anyway, so I guess it could have been worse.