### PR TITLE
#348 Disable the 'summary' option on forum topic body fields

### DIFF
--- a/sites/all/modules/custom/bg/bg.features.field_instance.inc
+++ b/sites/all/modules/custom/bg/bg.features.field_instance.inc
@@ -10,6 +10,87 @@
 function bg_field_default_field_instances() {
   $field_instances = array();
 
+  // Exported field_instance: 'node-forum-body'.
+  $field_instances['node-forum-body'] = array(
+    'bundle' => 'forum',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => '',
+    'display' => array(
+      'default' => array(
+        'label' => 'hidden',
+        'module' => 'text',
+        'settings' => array(),
+        'type' => 'text_default',
+        'weight' => 11,
+      ),
+      'homepage' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'teaser' => array(
+        'label' => 'hidden',
+        'module' => 'text',
+        'settings' => array(
+          'trim_length' => 600,
+        ),
+        'type' => 'text_summary_or_trimmed',
+        'weight' => 11,
+      ),
+    ),
+    'entity_type' => 'node',
+    'field_name' => 'body',
+    'label' => 'Body',
+    'required' => 0,
+    'settings' => array(
+      'better_formats' => array(
+        'allowed_formats' => array(
+          'f' => 'f',
+          'php_code' => 0,
+          'plain_text' => 0,
+          'u' => 0,
+          'xbbcode' => 0,
+        ),
+        'allowed_formats_toggle' => 1,
+        'default_order_toggle' => 0,
+        'default_order_wrapper' => array(
+          'formats' => array(
+            'f' => array(
+              'weight' => -1,
+            ),
+            'php_code' => array(
+              'weight' => 11,
+            ),
+            'plain_text' => array(
+              'weight' => 10,
+            ),
+            'u' => array(
+              'weight' => 1,
+            ),
+            'xbbcode' => array(
+              'weight' => -6,
+            ),
+          ),
+        ),
+      ),
+      'display_summary' => 0,
+      'text_processing' => 1,
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 1,
+      'module' => 'text',
+      'settings' => array(
+        'rows' => 20,
+        'summary_rows' => 5,
+      ),
+      'type' => 'text_textarea_with_summary',
+      'weight' => 1,
+    ),
+  );
+
   // Exported field_instance: 'node-page-body'.
   $field_instances['node-page-body'] = array(
     'bundle' => 'page',


### PR DESCRIPTION
We export node-forum-body in order to save the setting to turn off its summary; we also in this case explicitly set the text format option on that field to 'f' only (note that this restriction applies to admin in addition to other users).