### PR TITLE
Point the 'Recent' menu item to node/

### DIFF
--- a/.tugboat/initialnodes.php
+++ b/.tugboat/initialnodes.php
@@ -108,7 +108,7 @@ $node->field_counts[$node->language][0]['value'] = 'Worldwide:[Cite:1028573][cit
 +15 classes';
 
 $node->status = 1;   // (1 or 0): published or unpublished
-$node->promote = 0;  // (1 or 0): promoted to front page or not
+$node->promote = 1;  // (1 or 0): promoted to front page or not
 $node->sticky = 0;  // (1 or 0): sticky at top of lists or not
 $node->comment = 1;  // 2 = comments open, 1 = comments closed, 0 = comments hidden
 // Add author of the node
@@ -132,7 +132,7 @@ $node->body[$node->language][0]['value'] = 'The Chelicerata.';
 $node->field_scientific_name[$node->language][0]['value'] = 'Chelicerata';
 
 $node->status = 1;   // (1 or 0): published or unpublished
-$node->promote = 0;  // (1 or 0): promoted to front page or not
+$node->promote = 1;  // (1 or 0): promoted to front page or not
 $node->sticky = 0;  // (1 or 0): sticky at top of lists or not
 $node->comment = 1;  // 2 = comments open, 1 = comments closed, 0 = comments hidden
 // Add author of the node
@@ -155,7 +155,7 @@ $node->field_scientific_name[$node->language][0]['value'] = 'Arachnida';
 $node->field_common_name[$node->language][0]['value'] = 'Arachnids';
 
 $node->status = 1;   // (1 or 0): published or unpublished
-$node->promote = 0;  // (1 or 0): promoted to front page or not
+$node->promote = 1;  // (1 or 0): promoted to front page or not
 $node->sticky = 0;  // (1 or 0): sticky at top of lists or not
 $node->comment = 1;  // 2 = comments open, 1 = comments closed, 0 = comments hidden
 // Add author of the node

--- a/sites/all/modules/custom/bg/bg.module
+++ b/sites/all/modules/custom/bg/bg.module
@@ -399,9 +399,16 @@ function bg_create_taxonomic_breadcrumb($node, $guidebc = 'Scientific name (Comm
 function bg_preprocess_page(&$vars) {
   global $user;
 
+  $current_path = request_path();
   // Don't change the path in administrative pages.
-  if (path_is_admin(current_path())) {
+  if (path_is_admin($current_path)) {
     return;
+  }
+
+  if ($current_path == 'node') {
+    // We're viewing the 'Recent' menu item, so add a 'Recent' breadcrumb.
+    $bc = array(l('Home', ''), l('Recent', 'node'));
+    drupal_set_breadcrumb($bc);
   }
 
   // Check that we have an nid in the path.

--- a/sites/all/modules/custom/bugguide/bugguide.install
+++ b/sites/all/modules/custom/bugguide/bugguide.install
@@ -16,7 +16,7 @@ function bugguide_install() {
     array('title' => 'Home', 'path' => '<front>'),
     array('title' => 'Guide', 'path' => 'node/3/bgpage'),
     array('title' => 'ID Request', 'path' => 'node/6/bgimage'),
-    array('title' => 'Recent', 'path' => 'recent'),
+    array('title' => 'Recent', 'path' => 'node'),
     array('title' => 'Frass', 'path' => 'node/9410/bgimage'),
     array('title' => 'Forums', 'path' => 'forum'),
     array('title' => 'Donate', 'path' => 'node/17109'),


### PR DESCRIPTION
This seems to do what we want: it includes bgimages, bgpages, book refs, and links, but not forum topics or pages.

In bugguide.install, where I changed the Recent pointer, ID Request points to /node/6/bgimage, but if I go to beta, ID Request points to id-request, so not sure if there's some other mechanism that will need to be updated for this to take effect on beta.

(Also locally I see extra stuff (a footer?) at the bottom of the /node page:
![image](https://user-images.githubusercontent.com/632915/133866597-aa3d23ac-7455-4bf2-a569-edfbcf8f6df2.png)
I don't see that at node/ on beta, which is what we want; I assume that will continue to be the case on beta.)