### PR TITLE
Update the bgimage create/edit form layout

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.features.field_instance.inc
+++ b/sites/all/modules/custom/bgimage/bgimage.features.field_instance.inc
@@ -292,7 +292,7 @@ function bgimage_field_default_field_instances() {
     'label' => 'Date taken',
     'required' => 0,
     'settings' => array(
-      'default_value' => 'now',
+      'default_value' => 'blank',
       'default_value2' => 'same',
       'default_value_code' => '',
       'default_value_code2' => '',
@@ -303,14 +303,14 @@ function bgimage_field_default_field_instances() {
       'module' => 'date',
       'settings' => array(
         'increment' => 15,
-        'input_format' => 'j M Y - g:i:sa',
+        'input_format' => 'n/j/y',
         'input_format_custom' => '',
         'label_position' => 'above',
-        'no_fieldset' => 0,
+        'no_fieldset' => 1,
         'text_parts' => array(),
         'year_range' => '1902:+0',
       ),
-      'type' => 'date_popup',
+      'type' => 'date_text',
       'weight' => 4,
     ),
   );

--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -1053,6 +1053,17 @@ function bgimage_get_series($nid) {
 }
 
 /**
+ * Implements hook_date_text_process_alter().
+ */
+function bgimage_date_text_process_alter(&$element, $form_state, $context) {
+  if (isset($element['date']['#description'])) {
+    // Hide the 'Format: 9/22/21' help text since we provide our own format
+    // hint in our field description.
+    unset($element['date']['#description']);
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function bgimage_form_bgimage_node_form_alter(&$form, &$form_state) {

--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -1073,17 +1073,6 @@ function bgimage_form_bgimage_node_form_alter(&$form, &$form_state) {
     $form['field_bgimage_base']['#access'] = FALSE;
   }
 
-  // If this is a cloned node and the original node had no date set, then do the
-  // same for this node (otherwise today's date is used as a default).
-  if (isset($form['clone_from_original_nid']['#value'])) {
-    $original_nid = $form['clone_from_original_nid']['#value'];
-    $original_node = node_load($original_nid);
-    if ($original_node && !$original_node->field_bgimage_date) {
-      unset($form['field_bgimage_date'][LANGUAGE_NONE][0]['#default_value']);
-      $form['field_bgimage_date'][LANGUAGE_NONE][0]['#default_value'] = array('value' => '');
-    }
-  }
-
   // Add a second submit button which allows the user to apply (most of) the
   // settings in the current form to all images in this series, but only if
   // we're currently cloning an image or this image is already one in a series.

--- a/sites/all/themes/bulmabug/css/bulma-bug.css
+++ b/sites/all/themes/bulmabug/css/bulma-bug.css
@@ -790,6 +790,17 @@ input#edit-submit-save-and-sync {
 }
 
 /* --------------------- */
+/* ## CREATE/EDIT FORMS
+/* --------------------- */
+
+/* This element is meant to display information about available text formats,
+ * but we only ever allow one, so the element is always empty but still takes
+ * up space. */
+#edit-body-und-0-format {
+  display: none;
+}
+
+/* --------------------- */
 /* ## MISC
 /* --------------------- */
 

--- a/sites/all/themes/bulmabug/css/bulma-bug.css
+++ b/sites/all/themes/bulmabug/css/bulma-bug.css
@@ -815,6 +815,13 @@ input#edit-submit-save-and-sync {
   display: inline-block;
 }
 
+/* The margins for these classes seem to be meant for dates with settings we're
+ * not using, so just reset them to 0. */
+.node-bgimage-form .form-type-date-text,
+.node-bgimage-form .form-item-field-bgimage-date-und-0-value-date {
+  margin-bottom: 0;
+}
+
 /* This element is meant to display information about available text formats,
  * but we only ever allow one, so the element is always empty but still takes
  * up space. */

--- a/sites/all/themes/bulmabug/css/bulma-bug.css
+++ b/sites/all/themes/bulmabug/css/bulma-bug.css
@@ -793,15 +793,33 @@ input#edit-submit-save-and-sync {
 /* ## CREATE/EDIT FORMS
 /* --------------------- */
 
+@media screen and (min-width: 1024px) {
+  /* Override bulma to display as block instead of grid. */
+  .node-bgimage-form .form-type-textfield,
+  .node-bgimage-form .form-type-select {
+    display: block;
+    max-width: unset;
+  }
+}
+
+.node-bgimage-form input[type=text] {
+  width:100%;
+}
+
+.node-bgimage-form .form-item:not(.form-type-checkbox) > label
+{
+  display: block;
+}
+
+.node-bgimage-form .form-type-checkbox {
+  display: inline-block;
+}
+
 /* This element is meant to display information about available text formats,
  * but we only ever allow one, so the element is always empty but still takes
  * up space. */
 #edit-body-und-0-format {
   display: none;
-}
-
-.node-bgimage-form .form-type-checkbox {
-  display: inline-block;
 }
 
 /* --------------------- */
@@ -818,11 +836,4 @@ input#edit-submit-save-and-sync {
 
 .bg-image-list .column {
     padding: 0.15rem;
-}
-
-@media screen and (min-width: 1024px) {
-  /* Override bulma to account for the long label of the county field. */
-  #field-bgimage-county-add-more-wrapper .form-type-textfield {
-    display: block;
-  }
 }

--- a/sites/all/themes/bulmabug/css/bulma-bug.css
+++ b/sites/all/themes/bulmabug/css/bulma-bug.css
@@ -800,6 +800,10 @@ input#edit-submit-save-and-sync {
   display: none;
 }
 
+.node-bgimage-form .form-type-checkbox {
+  display: inline-block;
+}
+
 /* --------------------- */
 /* ## MISC
 /* --------------------- */


### PR DESCRIPTION
John, I made the bgimage form look closer to current BugGuide with your comments factored in, but I'm happy to do more work to make it look whatever way you'd like it to look (in other words, this isn't my ideal image of the way I think it should look or anything like that, just something to work from).

I mentioned new date input issues in one of the commits: a result of the date picker popup no longer entering dates in the correct format for us - I chose the new date format to try to match the form we give the user (mm/dd/yy), but to be honest I'm not sure if it's better/less work to use that format and then alter/validate the input date for the other forms of dates we'll accept (like four digit years for example), or if a different format would be more useful/flexible(/necessary?) for us on the backend and then we would just do different validations/alters to create dates in that more useful format. If you'd like to sort that out in this pr that would be fine with me, otherwise we can create a new issue once/if this lands.

With these commits the user will (until we fix it) only be able to enter a year from 00-21 since any larger number would be interpreted as being in the future (e.g. 3/15/99 would be interpreted as 3/15/2099).

Also kind of curious what kinds of dates current BugGuide accepts.