### PR TITLE
#167,#242 Sort the images tab first by parent taxa nids, then by imag…

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -192,10 +192,8 @@ function bgimage_apachesolr_index_document_build_node($document, $entity, $env_i
   // Classification field used for sorting.
   $classification = '';
   if (!empty($entity->field_parent[LANGUAGE_NONE][0]['value'])) {
-    $classification = $entity->field_parent[LANGUAGE_NONE][0]['value'] . ',';
+    $document->addField('ss_bgimage_classification', $entity->field_parent[LANGUAGE_NONE][0]['value']);
   }
-  $classification .= $entity->nid;
-  $document->addField('ss_bgimage_classification', $classification);
 
   // Image thumbnail.
   $node_wrapper = entity_metadata_wrapper('node', $entity);

--- a/sites/all/modules/custom/bgpage/bgpage.ds.field.inc
+++ b/sites/all/modules/custom/bgpage/bgpage.ds.field.inc
@@ -152,9 +152,8 @@ function _bgpage_images($field) {
     $query->addParam('fl', 'entity_id,label,ss_bgimage_thumbnail,ss_bgimage_classification,is_bgimage_immediate_parent,sm_bgimage_parents,sm_bgimage_breadcrumbs');
     // Sort by classification (full list of parents including bgimage nid at the end),
     // and then by rating.
-    $query->addParam('sort', 'ss_bgimage_classification desc');
-    $query->addParam('sort', 'is_bgimage_rating_avg desc');
-    $query->addParam('sort', 'is_bgimage_rating_count desc');
+    $query->addParam('sort', 'ss_bgimage_classification asc');
+    $query->addParam('sort', 'entity_id desc');
     // Set paging and results per page.
     $query->page = pager_find_page();
     $query->addParam('rows', $results_per_page);

--- a/sites/all/modules/custom/bgpage/bgpage.ds.field.inc
+++ b/sites/all/modules/custom/bgpage/bgpage.ds.field.inc
@@ -150,8 +150,7 @@ function _bgpage_images($field) {
     // Configure query.
     $query->addFilterSubQuery($filter);
     $query->addParam('fl', 'entity_id,label,ss_bgimage_thumbnail,ss_bgimage_classification,is_bgimage_immediate_parent,sm_bgimage_parents,sm_bgimage_breadcrumbs');
-    // Sort by classification (full list of parents including bgimage nid at the end),
-    // and then by rating.
+    // Sort by full parent classification, and then by nid (most recent first).
     $query->addParam('sort', 'ss_bgimage_classification asc');
     $query->addParam('sort', 'entity_id desc');
     // Set paging and results per page.


### PR DESCRIPTION
…e nid

I think this replicates what current BugGuide does.

We're sorting first by parent nids, as a string of comma-separated parents - so sorted in dictionary order, where ',' comes before all digits - in ascending order (as on current BugGuide); and then by image entity_id = nid, which in solr is an integer, in descending order, so most recent images are displayed first.