### PR TITLE
#401 Hide the 'Extract image data' button unless an image is selected.

### DIFF
--- a/sites/all/modules/custom/bgimage/bgimage.module
+++ b/sites/all/modules/custom/bgimage/bgimage.module
@@ -669,7 +669,17 @@ function bgimage_preprocess_image_widget(&$variables) {
     // The filename that is shown is not the user's filename but rather our long
     // random string filename, so don't show it.
     $variables['element']['filename']['#access'] = FALSE;
+
     $variables['element']['upload_button']['#value'] = t('Extract image data');
+
+    // Only show the upload button when the user has selected a file.
+    $variables['element']['upload_button']['#states'] = array(
+      'visible' => array(
+        ':input[name="files[field_bgimage_image_und_0]"]' => array(
+          '!value' => ''
+        )
+      )
+    );
   }
 }
 


### PR DESCRIPTION
When you first edit an image node that already has an image, or after you've uploaded an image the user selected, the upload/extract button doesn't exist, instead there's a 'Remove' button.

Otherwise the upload button exists and this code using the '#states' value seems to do what we want by only making the button visible when the value of the file input is not '', i.e. visible only when a file has been selected.

[The #states notation '!value' => '' means "value != ''".]